### PR TITLE
Updated versioning system for automatic semantic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,42 +44,47 @@ jobs:
     - name: Install semantic-release
       run: npm install -g semantic-release @semantic-release/changelog @semantic-release/git
 
-    - name: Create .releaserc.json
+    - name: Generate commit message based on branch/PR
+      id: commit_type
       run: |
-        cat > .releaserc.json << 'EOF'
-        {
-          "branches": ["main"],
-          "plugins": [
-            "@semantic-release/commit-analyzer",
-            "@semantic-release/release-notes-generator",
-            "@semantic-release/changelog",
-            [
-              "@semantic-release/npm",
-              {
-                "npmPublish": false
-              }
-            ],
-            [
-              "@semantic-release/git",
-              {
-                "assets": ["package.json", "CHANGELOG.md"],
-                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-              }
-            ],
-            [
-              "@semantic-release/github",
-              {
-                "assets": [
-                  {
-                    "path": "*.vsix",
-                    "label": "VS Code Extension"
-                  }
-                ]
-              }
-            ]
-          ]
-        }
-        EOF
+        # Get the latest commit message (the merge commit)
+        COMMIT_MSG=$(git log -1 --pretty=format:"%s")
+        echo "Original commit: $COMMIT_MSG"
+
+        # Extract branch name from merge commit if it exists
+        if [[ $COMMIT_MSG =~ Merge\ pull\ request.*from.*/(.*) ]]; then
+          BRANCH_NAME="${BASH_REMATCH[1]}"
+          echo "Branch name: $BRANCH_NAME"
+
+          # Determine commit type based on branch prefix
+          if [[ $BRANCH_NAME =~ ^feature/.* ]] || [[ $BRANCH_NAME =~ ^feat/.* ]]; then
+            COMMIT_TYPE="feat"
+          elif [[ $BRANCH_NAME =~ ^fix/.* ]] || [[ $BRANCH_NAME =~ ^bugfix/.* ]] || [[ $BRANCH_NAME =~ ^hotfix/.* ]]; then
+            COMMIT_TYPE="fix"
+          elif [[ $BRANCH_NAME =~ ^docs/.* ]]; then
+            COMMIT_TYPE="docs"
+          elif [[ $BRANCH_NAME =~ ^refactor/.* ]]; then
+            COMMIT_TYPE="refactor"
+          elif [[ $BRANCH_NAME =~ ^test/.* ]]; then
+            COMMIT_TYPE="test"
+          elif [[ $BRANCH_NAME =~ ^chore/.* ]]; then
+            COMMIT_TYPE="chore"
+          else
+            # Default to patch for any other changes
+            COMMIT_TYPE="fix"
+          fi
+
+          # Create new conventional commit message
+          NEW_COMMIT_MSG="$COMMIT_TYPE: ${COMMIT_MSG#*\#*}"
+          NEW_COMMIT_MSG="${NEW_COMMIT_MSG% (*}"  # Remove PR number if present
+
+          echo "New commit message: $NEW_COMMIT_MSG"
+
+          # Amend the last commit with conventional format
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit --amend -m "$NEW_COMMIT_MSG"
+        fi
 
     - name: Release
       env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,68 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "feat", "release": "minor" },
+          { "type": "feature", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "hotfix", "release": "patch" },
+          { "type": "bugfix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "revert", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "style", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "ci", "release": "patch" },
+          { "type": "chore", "release": false },
+          { "scope": "no-release", "release": false }
+        ],
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        },
+        "writerOpts": {
+          "commitsSort": ["subject", "scope"]
+        }
+      }
+    ],
+    "@semantic-release/changelog",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          {
+            "path": "*.vsix",
+            "label": "VS Code Extension"
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# Project Memory
+
+## Semantic Versioning & Release Process
+
+### Branch-Based Automatic Versioning
+This project uses semantic-release with automatic version detection based on branch naming patterns when PRs are merged to main.
+
+**Branch naming conventions for automatic version bumps:**
+- `feature/*` or `feat/*` → **Minor version bump** (1.1.0 → 1.2.0)
+- `fix/*`, `bugfix/*`, `hotfix/*` → **Patch version bump** (1.1.0 → 1.1.1)
+- `docs/*` → **Patch version bump** (documentation changes)
+- `refactor/*` → **Patch version bump** (code refactoring)
+- `test/*` → **Patch version bump** (test changes)
+- `chore/*` → **No version bump** (maintenance)
+- Any other branch → **Patch version bump** (safe default)
+
+### Major Version Bumps (Manual Control)
+For breaking changes requiring a major version bump:
+- Add `BREAKING CHANGE:` or `BREAKING:` in the PR description or commit message
+- This will bump from 1.x.x → 2.0.0
+
+### Examples
+```bash
+# These branch names will auto-determine version bump:
+feature/add-new-sync-provider  # → minor bump
+fix/resolve-token-refresh      # → patch bump
+hotfix/critical-security-fix   # → patch bump
+chore/update-dependencies      # → no bump
+```
+
+### Release Configuration
+- Release workflow: `.github/workflows/release.yml`
+- Semantic-release config: `.releaserc.json`
+- Automatic versioning happens on main branch pushes from PR merges
+- No need to manually format commit messages - branch names control versioning


### PR DESCRIPTION
This PR updates the versioning system to use branch-based automatic semantic versioning:

## Changes:
- Added persistent `.releaserc.json` configuration
- Updated release workflow to auto-generate conventional commits from branch names
- Created CLAUDE.md with project memory for versioning conventions

## How it works:
- `feature/*` branches → minor version bump
- `fix/*` branches → patch version bump  
- Other branches → patch version bump (safe default)
- `chore/*` → no version bump

This should resolve the issue where versions were stuck at v1.0.0 and make releases much easier to manage via PR workflow.